### PR TITLE
change jolokia port name

### DIFF
--- a/packages/common/src/openshift/openshift.service.ts
+++ b/packages/common/src/openshift/openshift.service.ts
@@ -14,7 +14,7 @@ namespace Online {
 
   export class OpenShiftService extends EventEmitter {
 
-    readonly jolokiaPortQuery = '$.spec.containers[*].ports[?(@.name=="jolokia")]';
+    readonly jolokiaPortQuery = '$.spec.containers[*].ports[?(@.name=="custom-jolokia")]';
 
     private _loading = 0;
     private projects: any[] = [];

--- a/packages/integration/src/navigation/navigation.service.ts
+++ b/packages/integration/src/navigation/navigation.service.ts
@@ -32,8 +32,8 @@ namespace Online {
 
     getConnectUrl(pod: any) {
       const container = _.find(pod.spec.containers,
-        container => container.ports.some(port => port.name === 'jolokia'));
-      const port = _.find(container.ports, port => port.name === 'jolokia').containerPort;
+        container => container.ports.some(port => port.name === 'custom-jolokia'));
+      const port = _.find(container.ports, port => port.name === 'custom-jolokia').containerPort;
       const jolokiaPath = getManagementJolokiaPath(pod, port);
       return new URI()
         .path('/integration/')

--- a/packages/integration/src/navigation/pods-selector.directive.ts.old
+++ b/packages/integration/src/navigation/pods-selector.directive.ts.old
@@ -37,8 +37,8 @@ namespace Online {
 
       const getConnectUrl = function (pod) {
         const container = _.find(pod.spec.containers,
-          container => container.ports.some(port => port.name === 'jolokia'));
-        const port = _.find(container.ports, port => port.name === 'jolokia').containerPort;
+          container => container.ports.some(port => port.name === 'custom-jolokia'));
+        const port = _.find(container.ports, port => port.name === 'custom-jolokia').containerPort;
         return new URI()
           .path('/integration/')
           .query({

--- a/packages/online/src/discover/discover.module.ts
+++ b/packages/online/src/discover/discover.module.ts
@@ -67,11 +67,11 @@ namespace Online {
   }
 
   function jolokiaContainersFilter() {
-    return containers => (containers || []).filter(container => container.ports.some(port => port.name === 'jolokia'));
+    return containers => (containers || []).filter(container => container.ports.some(port => port.name === 'custom-jolokia'));
   }
 
   function jolokiaPortFilter() {
-    return container => container.ports.find(port => port.name === 'jolokia');
+    return container => container.ports.find(port => port.name === 'custom-jolokia');
   }
 
   function connectUrlFilter() {


### PR DESCRIPTION
to make hawtio work AVS need to disable jolokia authentication for all MS and future MS because having jolokia authentication does not work with hawtio. it keeps pop up basic authentication window. thats why easiest way to change the port name so that only that specific jolokia endpoint is available to hawtio. though still need to disable jolokia authentication for that MS.